### PR TITLE
fix: Countly.logException issues

### DIFF
--- a/Countly.js
+++ b/Countly.js
@@ -189,18 +189,27 @@ Countly.addCrashLog = function(crashLog){
 };
 Countly.logException = function(exception, nonfatal, segments){
     var exceptionString = "";
-    for(var i=0,il=exception.length;i<il;i++){
-        exceptionString += "columnNumber: " +exception[i].columnNumber +"\n";
-        exceptionString += "fileName: " +exception[i].fileName +"\n";
-        exceptionString += "functionName: " +exception[i].functionName +"\n";
-        exceptionString += "lineNumber: " +exception[i].lineNumber +"\n";
+    if (Array.isArray(exceptionString)) {
+        for(var i=0, il=exception.length; i<il; i++){
+            if (typeof exception[i] === 'string') {
+                exceptionString += exception[i] + "\n";
+            } else {
+                exceptionString += "columnNumber: " +exception[i].columnNumber + "\n";
+                exceptionString += "fileName: " +exception[i].fileName + "\n";
+                exceptionString += "functionName: " +exception[i].functionName + "\n";
+                exceptionString += "lineNumber: " +exception[i].lineNumber + "\n";
+            }
+        }
+    } else if (typeof exceptionString === "string") {
+        exceptionString = exception;
     }
+
     var args = [];
     args.push(exceptionString || "");
     args.push(nonfatal || false);
     for(var key in segments){
         args.push(key);
-        args.push(segments.toString());
+        args.push(segments[key].toString());
     }
     cordova.exec(Countly.onSuccess,Countly.onError,"CountlyCordova","logException",args);
 };

--- a/Countly.js
+++ b/Countly.js
@@ -189,7 +189,7 @@ Countly.addCrashLog = function(crashLog){
 };
 Countly.logException = function(exception, nonfatal, segments){
     var exceptionString = "";
-    if (Array.isArray(exceptionString)) {
+    if (Array.isArray(exception)) {
         for(var i=0, il=exception.length; i<il; i++){
             if (typeof exception[i] === 'string') {
                 exceptionString += exception[i] + "\n";
@@ -200,7 +200,7 @@ Countly.logException = function(exception, nonfatal, segments){
                 exceptionString += "lineNumber: " +exception[i].lineNumber + "\n";
             }
         }
-    } else if (typeof exceptionString === "string") {
+    } else if (typeof exception === "string") {
         exceptionString = exception;
     }
 


### PR DESCRIPTION
Segments were broken.

Also, you couldn't pass a plain string or array of strings, which is preferrable to an Error object sometimes.  

The documentation here shows that this should be possible: https://resources.count.ly/v1.0/docs/phonegap-icenium-meteor